### PR TITLE
made `vsmake.bat` pass thru the return value of `make`

### DIFF
--- a/bin/vsmake.bat
+++ b/bin/vsmake.bat
@@ -1,3 +1,7 @@
 @echo off
+setlocal EnableDelayedExpansion
 set PATH=%~dp0;%PATH%
-%~dp0make 2>&1 %1 %2 %3 %4 %5 | %~dp0sed -e "s/\([^:]*\):\([0-9][0-9]*\)\(.*\)/\1 (\2) \3/"
+(%~dp0make 2>&1 %1 %2 %3 %4 %5 ^& ^>err.tmp call echo %%^^errorlevel%%) | %~dp0sed -e "s/\([^:]*\):\([0-9][0-9]*\)\(.*\)/\1 (\2) \3/"
+set /p "leftErr=" <err.tmp
+del err.tmp
+exit /b %leftErr%


### PR DESCRIPTION
Return value is necessary to inform Visual Studio of a failed build. This allows it to be passed via the `errorlevel` variable.

I'm planning to do a pull request for WFP as well to put this to use.